### PR TITLE
Callables.toString (and hence asString) are now null-safe

### DIFF
--- a/src/com/googlecode/totallylazy/Callables.java
+++ b/src/com/googlecode/totallylazy/Callables.java
@@ -239,7 +239,7 @@ public final class Callables {
 
     public final static Function1<Object, String> toString = new Function1<Object, String>() {
         public final String call(final Object value) {
-            return value.toString();
+            return value != null ? value.toString() : null;
         }
 
         @Override

--- a/test/com/googlecode/totallylazy/CallablesTest.java
+++ b/test/com/googlecode/totallylazy/CallablesTest.java
@@ -1,5 +1,6 @@
 package com.googlecode.totallylazy;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import static com.googlecode.totallylazy.Callables.when;
@@ -9,6 +10,7 @@ import static com.googlecode.totallylazy.matchers.NumberMatcher.is;
 import static com.googlecode.totallylazy.numbers.Numbers.add;
 import static com.googlecode.totallylazy.numbers.Numbers.even;
 import static com.googlecode.totallylazy.numbers.Numbers.primes;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CallablesTest {
@@ -38,5 +40,10 @@ public class CallablesTest {
     @Test
     public void canReplaceInline() {
         assertThat(primes().map(when(even(), constant((Number) 0))).take(5), hasExactly(0, 3, 5, 7, 11));
+    }
+
+    @Test
+    public void canInvokeToStringOnNull() {
+        assertThat(Callables.toString.apply(null), CoreMatchers.is(nullValue()));
     }
 }


### PR DESCRIPTION
Damn you nulls! You win again!
