### PR TITLE
Fix reduceRight behavior

### DIFF
--- a/src/com/googlecode/totallylazy/Iterators.java
+++ b/src/com/googlecode/totallylazy/Iterators.java
@@ -173,11 +173,22 @@ public class Iterators {
     }
 
     public static <T, S> S reduceRight(final Iterator<? extends T> iterator, final Callable2<? super T, ? super S, ? extends S> callable) {
-        return foldRight(iterator, Unchecked.<S>cast(iterator.next()), callable);
+        Iterator<T> reversed = reverse(iterator);
+        return foldLeft(reversed, Unchecked.<S>cast(reversed.next()), Callables.flip(callable));
     }
 
     public static <T, S> S reduceRight(final Iterator<? extends T> iterator, final Callable1<? super Pair<T, S>, ? extends S> callable) {
-        return foldRight(iterator, Unchecked.<S>cast(iterator.next()), callable);
+        if (!iterator.hasNext())
+            throw new NoSuchElementException();
+        T head = iterator.next();
+        if (!iterator.hasNext())
+            return Unchecked.<S>cast(head);
+        return Callers.call(callable, Pair.pair(returns(head), new Function<S>() {
+            @Override
+            public S call() throws Exception {
+                return reduceRight(iterator, callable);
+            }
+        }));
     }
 
     public static String toString(final Iterator<?> iterator, final String separator) {

--- a/test/com/googlecode/totallylazy/IteratorsTest.java
+++ b/test/com/googlecode/totallylazy/IteratorsTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static com.googlecode.totallylazy.Arrays.list;
 import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.Strings.join;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -23,6 +24,13 @@ public class IteratorsTest {
         assertThat(Iterators.equalsTo(sequence(1, null, 3).iterator(), sequence(1, 2, 3).iterator()), is(false));
         assertThat(Iterators.equalsTo(sequence(1, 2, 3).iterator(), sequence(1, null, 3).iterator()), is(false));
         assertThat(Iterators.equalsTo(sequence(1, null, 3).iterator(), sequence(1, null, 3).iterator()), is(true));
+    }
 
+    @Test
+    public void supportsReduceAndFold() throws Exception {
+        assertThat(Iterators.reduceRight(sequence("a", "b", "c").iterator(), join), is("abc"));
+        assertThat(Iterators.reduceLeft(sequence("a", "b", "c").iterator(), join), is("abc"));
+        assertThat(Iterators.foldRight(sequence("a", "b", "c").iterator(), "d", join), is("abcd"));
+        assertThat(Iterators.foldLeft(sequence("a", "b", "c").iterator(), "0", join), is("0abc"));
     }
 }

--- a/test/com/googlecode/totallylazy/SequenceTest.java
+++ b/test/com/googlecode/totallylazy/SequenceTest.java
@@ -191,11 +191,13 @@ public class SequenceTest {
     @Test
     public void supportsReduceRight() throws Exception {
         assertThat(numbers(1, 2, 3).reduceRight(add()), NumberMatcher.is(6));
+        assertThat(sequence("1", "2", "3").reduceRight(Strings.join), is("123"));
     }
 
     @Test
     public void supportsFoldRight() throws Exception {
         assertThat(sequence(1, 2, 3).foldRight(0, add()), NumberMatcher.is(6));
+        assertThat(sequence("1", "2", "3").foldRight("4", Strings.join), is("1234"));
     }
 
     @Test
@@ -206,6 +208,15 @@ public class SequenceTest {
     @Test
     public void supportsReduceRightWithInfiniteSequenceIfFunctionTerminatesEarlyAndUsesPairs() throws Exception {
         assertThat(repeat(true).reduceRight(orPair()), is(true));
+        // first() implemented using reduceRight(pair)
+        assertThat(range(0).reduceRight(new Function1<Pair<Number, Number>, Number>() {
+            @Override
+            public Number call(Pair<Number, Number> p) throws Exception {
+                return p.first();
+            }
+        }), NumberMatcher.is(0));
+        // works well with finite sequence
+        assertThat(sequence("a", "b", "c").reduceRight(Strings.join.pair()), is("abc"));
     }
 
     @Test
@@ -600,6 +611,8 @@ public class SequenceTest {
     public void supportsReduceLeft() throws Exception {
         assertThat(numbers(1, 2, 3).reduce(sum()), NumberMatcher.is(6));
         assertThat(numbers(1, 2, 3).reduceLeft(sum()), NumberMatcher.is(6));
+        assertThat(sequence("1", "2", "3").reduce(Strings.join), is("123"));
+        assertThat(sequence("1", "2", "3").reduceLeft(Strings.join), is("123"));
     }
 
     @Test
@@ -614,6 +627,8 @@ public class SequenceTest {
     public void supportsFoldLeft() throws Exception {
         assertThat(sequence(1, 2, 3).fold(0, sum()), NumberMatcher.is(6));
         assertThat(sequence(1, 2, 3).foldLeft(0, sum()), NumberMatcher.is(6));
+        assertThat(sequence("1", "2", "3").fold("0", Strings.join), is("0123"));
+        assertThat(sequence("1", "2", "3").foldLeft("0", Strings.join), is("0123"));
     }
 
     @Test


### PR DESCRIPTION
Current reduceRight() implementation delegates to foldRight with 'first' value as seed, which is wrong.

I added some tests which reveals this using String concatenation.

    assertThat(sequence("1", "2", "3").reduceRight(Strings.join), is("123"));

The test above fails with the actual value of "231".

Similarly reduceRight() which uses Pair for laziness was corrected accordingly. 
