### PR TITLE
Ryan, Olga, Liam: adding support for UTF-16

### DIFF
--- a/src/com/googlecode/totallylazy/Xml.java
+++ b/src/com/googlecode/totallylazy/Xml.java
@@ -30,12 +30,14 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static com.googlecode.totallylazy.Strings.UTF8;
 import static com.googlecode.totallylazy.Strings.bytes;
 import static com.googlecode.totallylazy.Strings.string;
 import static com.googlecode.totallylazy.xml.FunctionResolver.resolver;
@@ -278,7 +280,7 @@ public class Xml {
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
             documentBuilder.setEntityResolver(ignoreEntities());
             documentBuilder.setErrorHandler(null);
-            return documentBuilder.parse(new ByteArrayInputStream(bytes(xml)));
+            return documentBuilder.parse(new InputSource(new InputStreamReader(new ByteArrayInputStream(bytes(xml)), UTF8)));
         } catch (Exception e) {
             throw LazyException.lazyException(e);
         }

--- a/test/com/googlecode/totallylazy/XmlTest.java
+++ b/test/com/googlecode/totallylazy/XmlTest.java
@@ -100,4 +100,12 @@ public class XmlTest {
         boolean value = Xml.matches(document, "count(//child) = 1");
         assertThat(value, is(true));
     }
+
+    @Test
+    public void supportsUTF16() throws Exception {
+        Document document = Xml.document("<?xml version=\"1.0\" encoding=\"UTF-16\" standalone=\"no\"?>\n"+
+                "<root><child><name>bob</name></child></root>");
+        Number value = Xml.selectNumber(document, "count(//child)");
+        assertThat(value, NumberMatcher.is(1));
+    }
 }


### PR DESCRIPTION
Previously we were not able to parse xmls encoded with UTF-16; when attempting to do it the Xml.document(xml) was throwing an exception: 

com.googlecode.totallylazy.LazyException: org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 56; Content is not allowed in prolog.
	at com.googlecode.totallylazy.LazyException.lazyException(LazyException.java:15)
	at com.googlecode.totallylazy.Xml.document(Xml.java:283)
......
Caused by: org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 56; Content is not allowed in prolog.
	at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:257)
	at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:347)
	at javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:121)
	at com.googlecode.totallylazy.Xml.document(Xml.java:281)
	... 27 more