### PR TITLE
RFC822 formatted dates default to GMT, as UTC isn't a supported timezone

### DIFF
--- a/src/com/googlecode/totallylazy/time/Dates.java
+++ b/src/com/googlecode/totallylazy/time/Dates.java
@@ -30,6 +30,7 @@ public class Dates {
     public static final String APACHE = "dd/MMM/yyyy:HH:mm:ss Z";
 
     public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final TimeZone GMT = TimeZone.getTimeZone("GMT");
     public static final Date MIN_VALUE = date(Long.MIN_VALUE);
     public static final Date MAX_VALUE = date(Long.MAX_VALUE);
     @Deprecated
@@ -45,8 +46,12 @@ public class Dates {
     }
 
     public static SimpleDateFormat format(final String pattern) {
+        return formatWithDefaultZone(pattern, UTC);
+    }
+
+    private static SimpleDateFormat formatWithDefaultZone(String pattern, TimeZone defaultTimeZone) {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern, Locale.ENGLISH);
-        simpleDateFormat.setTimeZone(UTC);
+        simpleDateFormat.setTimeZone(defaultTimeZone);
         simpleDateFormat.setLenient(false);
         return simpleDateFormat;
     }
@@ -64,7 +69,7 @@ public class Dates {
     }
 
     public static DateFormat RFC822() {
-        return format(RFC822);
+        return formatWithDefaultZone(RFC822, GMT);
     }
 
     public static DateFormat RFC3339withMilliseconds() {

--- a/test/com/googlecode/totallylazy/time/DatesTest.java
+++ b/test/com/googlecode/totallylazy/time/DatesTest.java
@@ -8,6 +8,8 @@ import java.util.Date;
 
 import static com.googlecode.totallylazy.time.Dates.date;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
 public class DatesTest {
@@ -74,5 +76,11 @@ public class DatesTest {
         assertThat(Dates.dayOfYear().apply(date(2013,12,31,0,0,0,0)), is(365));
         assertThat(Dates.year().apply(date(2013,1,1,0,0,0,0)), is(2013));
         assertThat(Dates.calendarField(Calendar.MONTH).apply(date(2013,1,1,0,0,0,0)), is(Calendar.JANUARY));
+    }
+
+    @Test
+    public void whenCreatingRFC822DateFromDateSetTimezoneToGMT() throws Exception {
+        String result = Dates.RFC822().format(new Date(1200000000000L));
+        assertThat(result, endsWith(" GMT"));
     }
 }


### PR DESCRIPTION
RFC822 doesn't include UTC as a supported timezone (UT/GMT are the supported alternatives). As such, some of the stricter parsers break on TotallyLazy produced dates.

Given the Java 8 RFC1123 date/time format doesn't support UT (or the US/military zones, a fact carefully hidden in the JavaDoc), I've changed the default timezone for RFC822 dates only to use GMT.