### PR TITLE
Added 'com.googlecode.totallylazy.trace' property to toggle trace output

### DIFF
--- a/src/com/googlecode/totallylazy/Debug.java
+++ b/src/com/googlecode/totallylazy/Debug.java
@@ -3,6 +3,8 @@ package com.googlecode.totallylazy;
 import static java.lang.management.ManagementFactory.getRuntimeMXBean;
 
 public class Debug {
+    private static final String TRACE_PROPERTY = "com.googlecode.totallylazy.trace";
+
     public static boolean inDebug() {
         return debugging();
     }
@@ -11,7 +13,11 @@ public class Debug {
         return getRuntimeMXBean().getInputArguments().toString().contains("-agentlib:jdwp");
     }
 
-    public static void trace(Exception e) {if (debugging()) e.printStackTrace();}
+    public static void trace(Exception e) {
+        if (debugging() && traceEnabled()) {
+            e.printStackTrace();
+        }
+    }
 
     public static class functions {
         public static <A,B> Mapper<A,B> trace(final Callable1<? super A,? extends B> callable) {
@@ -27,5 +33,10 @@ public class Debug {
                 }
             };
         }
+    }
+
+    private static boolean traceEnabled() {
+        String traceProperty = System.getProperty(TRACE_PROPERTY);
+        return traceProperty == null || Boolean.parseBoolean(traceProperty);
     }
 }

--- a/src/com/googlecode/totallylazy/Debug.java
+++ b/src/com/googlecode/totallylazy/Debug.java
@@ -13,9 +13,9 @@ public class Debug {
         return getRuntimeMXBean().getInputArguments().toString().contains("-agentlib:jdwp");
     }
 
-    public static void trace(Exception e) {
+    public static void trace(Throwable throwable) {
         if (debugging() && traceEnabled()) {
-            e.printStackTrace();
+            throwable.printStackTrace();
         }
     }
 

--- a/test/com/googlecode/totallylazy/DebugTest.java
+++ b/test/com/googlecode/totallylazy/DebugTest.java
@@ -1,0 +1,69 @@
+package com.googlecode.totallylazy;
+
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintStream;
+
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+public class DebugTest {
+
+    private final StringPrintStream stdErr = new StringPrintStream();
+
+    private PrintStream originalStdErr;
+
+    @Before
+    public void redirectSystemErr() {
+        originalStdErr = System.err;
+        System.setErr(stdErr);
+    }
+
+    @After
+    public void resetSystemErr() {
+        System.setErr(originalStdErr);
+    }
+
+    @Test
+    public void exceptionsAreNotPrintedToSystemErrorWhenJvmDebuggingIsDisabled() throws Exception {
+        assumeThat(jvmArguments(), not(containsDebuggingAgent()));
+
+        Debug.trace(new RuntimeException("aTestException"));
+
+        assertThat(stdErr.toString(), not(containsString("aTestException")));
+    }
+
+    @Test
+    public void exceptionsArePrintedToSystemErrorWhenJvmDebuggingIsEnabled() throws Exception {
+        assumeThat(jvmArguments(), containsDebuggingAgent());
+
+        Debug.trace(new RuntimeException("aTestException"));
+
+        assertThat(stdErr.toString(), containsString("aTestException"));
+    }
+
+    @Test
+    public void exceptionsAreNotPrintedToSystemErrorWhenJvmDebuggingIsEnabledAndSuppressionArgumentIsPresent() throws Exception {
+        assumeThat(jvmArguments(), containsDebuggingAgent());
+        System.setProperty("com.googlecode.totallylazy.trace", "false");
+
+        Debug.trace(new RuntimeException("aTestException"));
+
+        assertThat(stdErr.toString(), not(containsString("aTestException")));
+    }
+
+    private Matcher<String> containsDebuggingAgent() {
+        return containsString("-agentlib:jdwp");
+    }
+
+    private String jvmArguments() {
+        return getRuntimeMXBean().getInputArguments().toString();
+    }
+
+}


### PR DESCRIPTION
It looks like the utterlyidle change was not enough - this trace logging happens in multiple places. So this pull modifies Debug.trace() to check a system property. Once in place, Utterlyidle can then be altered via a future pull req to remove the property check and call Debug.trace(), nicely centralising that behaviour.

Sorry for the trail of pulls... it's mostly Jack's fault.